### PR TITLE
Add executor tests

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,12 +1,14 @@
 use crate::consumer::Consumer;
 use crate::middleware::Middleware;
 use crate::watcher::Watcher;
+use std::error::Error;
 use std::fmt::Debug;
+use std::marker::Copy;
 use tokio::sync::broadcast;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
-pub struct Executor<T: Send + Sync + Clone + Debug + 'static> {
+pub struct Executor<T: Send + Sync + Clone + Copy + Debug + 'static> {
     watchers: Vec<Box<dyn Watcher<Payload = T> + Send + Sync>>,
     middlewares: Vec<Box<dyn Middleware<Payload = T> + Send + Sync>>,
     consumer: Option<Box<dyn Consumer<Payload = T> + Send + Sync>>,
@@ -15,7 +17,7 @@ pub struct Executor<T: Send + Sync + Clone + Debug + 'static> {
 
 impl<T> Executor<T>
 where
-    T: Send + Sync + Clone + Debug + 'static,
+    T: Send + Sync + Clone + Debug + Copy + 'static,
 {
     pub fn new() -> Executor<T> {
         return Executor {
@@ -30,88 +32,136 @@ where
         self.watchers.push(w);
     }
 
-    pub fn set_listener(&mut self, l: Box<dyn Consumer<Payload = T> + Send + Sync>) {
-        self.consumer = Some(l);
+    pub fn add_middleware(&mut self, m: Box<dyn Middleware<Payload = T> + Send + Sync>) {
+        self.middlewares.push(m);
     }
 
     pub fn add_listener(&mut self, l: Box<dyn Consumer<Payload = T> + Send + Sync>) {
         self.consumers.push(l);
     }
 
-    pub fn add_middleware(&mut self, m: Box<dyn Middleware<Payload = T> + Send + Sync>) {
-        self.middlewares.push(m);
+    pub fn set_listener(&mut self, l: Box<dyn Consumer<Payload = T> + Send + Sync>) {
+        self.consumer = Some(l);
     }
 
-    pub async fn start(self) {
+    fn start_watchers(&mut self, sx: mpsc::Sender<T>) -> Vec<JoinHandle<()>> {
+        start_watchers(&mut self.watchers, sx)
+    }
+
+    fn start_middlewares(&mut self, rx: mpsc::Receiver<T>) -> (Vec<JoinHandle<()>>, mpsc::Receiver<T>) {
+        start_middlewares(&mut self.middlewares, rx)
+    }
+
+    fn start_consumers(&mut self, rx: mpsc::Receiver<T>) -> Vec<JoinHandle<()>> {
+        start_consumers(&mut self.consumers, rx)
+    }
+
+    pub async fn start(mut self) -> Result<(), Box<dyn Error>> {
         // create first channel
         let (sx, rx): (mpsc::Sender<T>, mpsc::Receiver<T>) = mpsc::channel(32);
 
         // create vector of JoinHandles to be awaited later
         let mut handles: Vec<JoinHandle<()>> = Vec::new();
 
-        for w in self.watchers {
-            /*
-             * Each Watcher expects a Sender channel
-             * They will send any "found" values through this channel
-             * Each gets its own clone, all feed into the same Receiver
-             */
-            let sxw = sx.clone();
-            let handle = tokio::spawn(async move {
-                w.watch(sxw).await;
-            });
-            handles.push(handle);
-        }
+        handles.append(&mut self.start_watchers(sx));
 
-        // All watcher values received on this channel
-        let mut watchers_receiver = rx;
-
-        for mw in self.middlewares.into_iter() {
-            /*
-             * Each middleware expects a Sender and Receiver
-             * We create a new Sender for each one and pipe them together
-             */
-            let (sxn, rxn): (mpsc::Sender<T>, mpsc::Receiver<T>) = mpsc::channel(10);
-            let mw_handle = tokio::spawn(async move {
-                mw.process(sxn, watchers_receiver).await;
-            });
-            watchers_receiver = rxn;
-            handles.push(mw_handle);
-        }
+        let (mut mw_handles, watchers_receiver) = self.start_middlewares(rx);
+        handles.append(&mut mw_handles);
 
         if !self.consumers.is_empty() {
-            // Now we need to switch to a broadcast channel, to support multiple Consumers
-            // We need to pipe the middleware output to a broadcast Sender
-
-            let (bsx, _): (broadcast::Sender<T>, broadcast::Receiver<T>) = broadcast::channel(16);
-
-            let bsx_pipe_input = bsx.clone();
-            let mw_to_consumers_handle = tokio::spawn(async move {
-                while let Some(r) = watchers_receiver.recv().await {
-                    bsx_pipe_input.send(r).unwrap();
-                }
-            });
-
-            handles.push(mw_to_consumers_handle);
-
-            // Then clone receivers and pass one to each Consumer
-            for l in self.consumers {
-                let brx = bsx.subscribe();
-                let listener = tokio::spawn(async move {
-                    l.consume_broadcast(brx).await;
-                });
-                handles.push(listener);
-            }
+            handles.append(&mut self.start_consumers(watchers_receiver));
         } else {
-            // single consumer, stick with mpsc
-            if let Some(c) = self.consumer {
+            if let Some(l) = self.consumer {
                 let listener = tokio::spawn(async move {
-                    c.consume(watchers_receiver).await;
+                    l.consume(watchers_receiver).await;
                 });
-                listener.await.unwrap();
+                listener.await?;
             }
         }
+
         for handle in handles {
-            handle.await.unwrap();
+            handle.await?;
         }
+        Ok(())
     }
+}
+
+fn start_watchers<T: Send + Sync + 'static>(
+    watchers: &mut Vec<Box<dyn Watcher<Payload = T> + Send + Sync>>,
+    sx: mpsc::Sender<T>,
+) -> Vec<JoinHandle<()>> {
+    let mut handles = vec![];
+
+    // All watcher values received on this channel
+
+    while let Some(mw) = watchers.pop() {
+        /*
+         * Each middleware expects a Sender and Receiver
+         * We create a new Sender for each one and pipe them together
+         */
+        let sxn = sx.clone();
+        let mw_handle = tokio::spawn(async move {
+            mw.watch(sxn).await;
+        });
+        handles.push(mw_handle);
+    }
+
+    handles
+}
+
+fn start_middlewares<T: Send + Sync + 'static>(
+    mws: &mut Vec<Box<dyn Middleware<Payload = T> + Send + Sync>>,
+    rx: mpsc::Receiver<T>,
+) -> (Vec<JoinHandle<()>>, mpsc::Receiver<T>) {
+    let mut handles = vec![];
+
+    // All watcher values received on this channel
+    let mut watchers_receiver = rx;
+
+    while let Some(mw) = mws.pop() {
+        /*
+         * Each middleware expects a Sender and Receiver
+         * We create a new Sender for each one and pipe them together
+         */
+        let (sxn, rxn): (mpsc::Sender<T>, mpsc::Receiver<T>) = mpsc::channel(10);
+        let mw_handle = tokio::spawn(async move {
+            mw.process(sxn, watchers_receiver).await;
+        });
+        watchers_receiver = rxn;
+        handles.push(mw_handle);
+    }
+
+    (handles, watchers_receiver)
+}
+
+fn start_consumers<T: Send + Sync + Clone + Debug + 'static>(
+    consumers: &mut Vec<Box<dyn Consumer<Payload = T> + Send + Sync>>,
+    mut rx: mpsc::Receiver<T>,
+) -> Vec<JoinHandle<()>> {
+    let mut handles = vec![];
+    // Now we need to switch to a broadcast channel, to support multiple Consumers
+    // We need to pipe the middleware output to a broadcast Sender
+
+    let (bsx, _): (broadcast::Sender<T>, broadcast::Receiver<T>) = broadcast::channel(16);
+
+    let bsx_pipe_input = bsx.clone();
+    let mw_to_consumers_handle = tokio::spawn(async move {
+        while let Some(r) = rx.recv().await {
+            bsx_pipe_input
+                .send(r)
+                .expect("failed passing message from middlewares to consumers");
+        }
+    });
+
+    handles.push(mw_to_consumers_handle);
+
+    // Then clone receivers and pass one to each Consumer
+    while let Some(l) = consumers.pop() {
+        let brx = bsx.subscribe();
+        let listener = tokio::spawn(async move {
+            l.consume_broadcast(brx).await;
+        });
+        handles.push(listener);
+    }
+    handles
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,52 @@ pub use watcher::Watcher;
 
 #[cfg(test)]
 mod tests {
-    #[test]
-    fn it_works() {
-        let result = 2 + 2;
-        assert_eq!(result, 4);
+    use async_trait::async_trait;
+    use crate::executor::Executor;
+
+    #[derive(Debug, Default)]
+    struct TestWorker {}
+
+    #[async_trait]
+    impl crate::Watcher for TestWorker {
+        type Payload = u32;
+
+        async fn watch(&self, sx: tokio::sync::mpsc::Sender<u32>) {
+            sx.send(1u32).await.expect("failed to send number through channel");
+        }
+    }
+
+    #[async_trait]
+    impl crate::Middleware for TestWorker {
+        type Payload = u32;
+        async fn process(&self, sx: tokio::sync::mpsc::Sender<Self::Payload>, mut rx: tokio::sync::mpsc::Receiver<Self::Payload>) {
+            if let Some(n) = rx.recv().await {
+                sx.send(n + 1_u32).await.expect("failed to send number through channel");
+            }
+        }
+    }
+
+    #[async_trait]
+    impl crate::Consumer for TestWorker {
+        type Payload = u32;
+        async fn consume(&self, mut rx: tokio::sync::mpsc::Receiver<Self::Payload>) {
+            if let Some(n) = rx.recv().await {
+                assert!(n == 2, "Did not consume expected value");
+            }
+        }
+        async fn consume_broadcast(&self, mut rx: tokio::sync::broadcast::Receiver<Self::Payload>) {
+            if let Ok(n) = rx.recv().await {
+                assert!(n == 2, "Did not consume expected value");
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn it_works() {
+        let mut executor: Executor<u32> = Executor::new();
+        executor.add_watcher(Box::new(TestWorker{}));
+        executor.add_middleware(Box::new(TestWorker{}));
+        executor.add_listener(Box::new(TestWorker{}));
+        executor.start().await.expect("Failed to start executor");
     }
 }


### PR DESCRIPTION
Adds basic tests to executor, with a single watcher, middleware, and consumer

tests the modules communicate as expected, and the middleware's effects are seen by the consumer

closes #3 